### PR TITLE
Add book links and QR code overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Douglas D. Mitchell is passionate about the intersection of psychology and perso
 ### The Confident Mind (2025)
 A comprehensive guide designed to equip readers with the "secret code" to understanding minds – their own and others' – and shaping behavior for the better.
 
+- [Landing Page](https://senpai-sama7.github.io/The-Confident-Mind---BONUS/)
+- [Buy on Amazon](https://www.amazon.com/s?k=The+Confident+Mind+Douglas+Mitchell)
+- [Audio & Video Overview](https://douglasmitchell.info/qr.html)
+
 ### The Influence Matrix Unveiled (2025)
 Before others use it against you - master the art of understanding and ethical influence through psychological insights.
 

--- a/index.html
+++ b/index.html
@@ -216,7 +216,11 @@
           <h2 class="name">The Confident Mind</h2>
           <span class="badge" style="margin: 10px 0;">Self-Help • Psychology • Personal Growth</span>
           <p class="meta" style="max-width: 60ch; margin: 20px auto;">A practical manual designed to help you repair, build, and sustain authentic confidence. This book provides actionable strategies to overcome self-doubt and master your mindset.</p>
-          <a href="https://a.co/d/ggjyIWA" target="_blank" rel="noopener" class="btn primary glass" style="margin-top: 20px;">Purchase on Amazon</a>
+          <div class="cta" style="margin-top: 20px;">
+            <a href="https://senpai-sama7.github.io/The-Confident-Mind---BONUS/" target="_blank" rel="noopener" class="btn glass">Landing Page</a>
+            <a href="https://www.amazon.com/s?k=The+Confident+Mind+Douglas+Mitchell" target="_blank" rel="noopener" class="btn primary glass">Buy on Amazon</a>
+            <a href="qr.html" target="_blank" rel="noopener" class="btn glass">Audio &amp; Video Overview</a>
+          </div>
         </div>
       </div>
     </section>

--- a/qr.html
+++ b/qr.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>The Confident Mind – Overview QR Codes</title>
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; padding: 40px; }
+    .qr-container { display: flex; flex-direction: column; align-items: center; gap: 40px; }
+    .qr-item img { width: 200px; height: 200px; }
+  </style>
+</head>
+<body>
+  <h1>The Confident Mind</h1>
+  <p>Scan a code below to access the book's audio or video overview.</p>
+  <div class="qr-container">
+    <div class="qr-item">
+      <h2>Audio Overview</h2>
+      <a href="assets/the-confident-mind-audio-overview.mp3">
+        <img src="https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=https%3A%2F%2Fdouglasmitchell.info%2Fassets%2Fthe-confident-mind-audio-overview.mp3" alt="QR code for audio overview" />
+      </a>
+      <p><a href="assets/the-confident-mind-audio-overview.mp3">Listen to the audio overview</a></p>
+      <audio controls src="assets/the-confident-mind-audio-overview.mp3" style="width: 100%; max-width: 400px; margin-top: 10px;"></audio>
+    </div>
+    <div class="qr-item">
+      <h2>Video Overview</h2>
+      <a href="assets/the-confident-mind-video-overview.mp4">
+        <img src="https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=https%3A%2F%2Fdouglasmitchell.info%2Fassets%2Fthe-confident-mind-video-overview.mp4" alt="QR code for video overview" />
+      </a>
+      <p><a href="assets/the-confident-mind-video-overview.mp4">Watch the video overview</a></p>
+      <video controls src="assets/the-confident-mind-video-overview.mp4" width="320" style="margin-top: 10px;"></video>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Link to book landing page, Amazon purchase, and overview QR codes from the book section
- Add qr.html with QR codes plus audio and video overview players
- Document landing, Amazon, and overview links in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bb0f41af208330bf1e39abefc9e8d0