### PR TITLE
Gravatar docs + admin setup & passkey fixes; UI copy and theme refinements

### DIFF
--- a/LLMS.TXT
+++ b/LLMS.TXT
@@ -1,0 +1,143 @@
+# Gravatar API Documentation v3.0.0 – LLMS.TXT
+
+This document is optimized for AI development environments (Cursor, Windsurf, Bolt, v0, Lovable, Claude, OpenAI, Gemini, and similar assistants). It provides practical, implementation-ready guidance for integrating Gravatar profile and avatar data.
+
+## 1) What Gravatar is
+
+Gravatar provides globally recognized avatars and basic public profile information keyed by an email-address hash.
+
+Common uses:
+- Show user avatars in comments, forums, and admin portals.
+- Enrich profile cards with public Gravatar profile metadata.
+- Provide fallback identity visuals when local profile photos are absent.
+
+## 2) Core integration model
+
+### Input
+- User email address (raw string, e.g. `user@example.com`).
+
+### Required transform
+- Trim whitespace.
+- Lowercase.
+- Hash with SHA-256 (recommended modern approach).
+
+### Output
+- A deterministic hash string used in Gravatar URLs.
+
+## 3) API endpoints
+
+### 3.1 Avatar image endpoint
+
+GET avatar image by hash:
+
+- `https://gravatar.com/avatar/{HASH}`
+
+Common query params:
+- `s=<size>`: image size in pixels (1-2048).
+- `d=<default>`: fallback image strategy (`404`, `mp`, `identicon`, `monsterid`, `wavatar`, `retro`, `robohash`, `blank`, or URL-encoded image URL).
+- `r=<rating>`: max content rating (`g`, `pg`, `r`, `x`).
+
+Example:
+`https://gravatar.com/avatar/{HASH}?s=160&d=identicon&r=g`
+
+### 3.2 Profile endpoint
+
+GET profile JSON by hash:
+
+- `https://gravatar.com/{HASH}.json`
+
+Typical response includes:
+- `entry[].id`
+- `entry[].displayName`
+- `entry[].preferredUsername`
+- `entry[].thumbnailUrl`
+- `entry[].profileUrl`
+- `entry[].aboutMe`
+- `entry[].currentLocation`
+- `entry[].urls[]`
+- `entry[].photos[]`
+
+## 4) Production-safe implementation notes
+
+1. Never send raw emails to Gravatar endpoints.
+2. Always hash client-provided email before URL construction.
+3. If profile endpoint returns non-200, degrade gracefully to local avatar defaults.
+4. Cache successful avatar/profile responses where possible to reduce external calls.
+5. Respect user privacy expectations: document externally fetched profile behavior in your privacy policy.
+
+## 5) TypeScript reference implementation
+
+```ts
+import { createHash } from 'node:crypto';
+
+export function gravatarHash(email: string): string {
+  return createHash('sha256').update(email.trim().toLowerCase(), 'utf8').digest('hex');
+}
+
+export function gravatarAvatarUrl(hash: string, size = 160): string {
+  const params = new URLSearchParams({
+    s: String(size),
+    d: 'identicon',
+    r: 'g',
+  });
+
+  return `https://gravatar.com/avatar/${hash}?${params.toString()}`;
+}
+
+export async function fetchGravatarProfile(hash: string) {
+  const response = await fetch(`https://gravatar.com/${hash}.json`, {
+    headers: { Accept: 'application/json' },
+    cache: 'force-cache',
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return (await response.json()) as unknown;
+}
+```
+
+## 6) Next.js server usage pattern
+
+- Compute hash in API route or server action.
+- Store only the hash and generated avatar URL if your product does not require profile enrichment.
+- For profile enrichment, perform fetch server-side and sanitize the payload before sending to the client.
+
+## 7) Error handling matrix
+
+- `404` avatar + `d=404`: no Gravatar image exists.
+- `404` profile endpoint: public profile not available.
+- `429` or transient 5xx: retry with backoff and short circuit to defaults.
+- Network timeout: use a local placeholder image immediately.
+
+## 8) Security and privacy checklist
+
+- [ ] No hardcoded secrets required for basic Gravatar reads.
+- [ ] Raw email never logged after hashing step.
+- [ ] External avatar/profile requests disclosed in privacy policy.
+- [ ] Client-facing API responses omit unnecessary third-party metadata.
+- [ ] Rate limiting applied if exposing profile lookup endpoint publicly.
+
+## 9) Quick test commands
+
+Replace `{HASH}` with a known test hash.
+
+```bash
+# Avatar headers check
+curl -I "https://gravatar.com/avatar/{HASH}?s=120&d=identicon&r=g"
+
+# Profile JSON check
+curl -s "https://gravatar.com/{HASH}.json" | jq
+```
+
+## 10) AI assistant prompt seed
+
+Use this short instruction when delegating avatar/profile tasks to coding agents:
+
+"Implement Gravatar with SHA-256 email hashing, server-side profile fetch, fallback-safe avatar URLs (`d=identicon`), and privacy-conscious logging (no raw email). Return typed utilities and integration tests."
+
+---
+
+Version: 3.0.0
+Intended audience: AI coding assistants + developers building production integrations.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ When not writing or consulting, you can find Douglas mentoring young professiona
 ---
 
 *"Confidence is not a fixed trait we simply have or lack; it's an ongoing practice. You are the architect of your own belief – build it strong, and build it with care."*
+
+## Developer Integration Docs
+
+- [Gravatar API Documentation v3.0.0 – LLMS.TXT](./LLMS.TXT)

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Eye, EyeOff, Lock, Mail, ArrowRight, Shield, Fingerprint } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -18,7 +18,55 @@ export default function AdminLoginPage() {
   const [rememberMe, setRememberMe] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
+  const [isSetupLoading, setIsSetupLoading] = useState(false);
+  const [hasAdminAccount, setHasAdminAccount] = useState(true);
   const { toast } = useToast();
+
+  useEffect(() => {
+    const checkAdminStatus = async () => {
+      try {
+        const response = await fetch('/api/admin/check');
+        if (!response.ok) {
+          return;
+        }
+
+        const data = await response.json();
+        setHasAdminAccount((data.adminCount ?? 0) > 0);
+      } catch {
+        setHasAdminAccount(true);
+      }
+    };
+
+    checkAdminStatus();
+  }, []);
+
+  const handleSetupAdmin = async () => {
+    setIsSetupLoading(true);
+    try {
+      const response = await fetch('/api/admin/setup', { method: 'POST' });
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Unable to enable admin portal');
+      }
+
+      toast({
+        title: 'Admin portal enabled',
+        description: 'The admin account is ready. Sign in with your admin email and password.',
+      });
+      setHasAdminAccount(true);
+      setEmail(data.email || 'admin@douglasmitchell.info');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to initialize admin user.';
+      toast({
+        title: 'Setup failed',
+        description: message,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSetupLoading(false);
+    }
+  };
 
   const handlePasskeyLogin = async () => {
     if (!email) {
@@ -34,7 +82,7 @@ export default function AdminLoginPage() {
 
     try {
       // 1. Get auth options
-      const optionsRes = await fetch('/api/admin/auth/passkey/authenticate/generate-options', {
+      const optionsRes = await fetch('/api/admin/auth/passkey/generate-options', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
@@ -51,7 +99,7 @@ export default function AdminLoginPage() {
       const authResp = await startAuthentication({ optionsJSON: options });
 
       // 3. Verify on server
-      const verifyRes = await fetch('/api/admin/auth/passkey/authenticate/verify', {
+      const verifyRes = await fetch('/api/admin/auth/passkey/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -70,11 +118,12 @@ export default function AdminLoginPage() {
         const error = await verifyRes.json();
         throw new Error(error.error || 'Verification failed');
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(error);
+      const message = error instanceof Error ? error.message : 'Authentication unsuccessful.';
       toast({
         title: 'Passkey failed',
-        description: error.message || 'Authentication unsuccessful.',
+        description: message,
         variant: 'destructive',
       });
     } finally {
@@ -156,6 +205,21 @@ export default function AdminLoginPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
+            {!hasAdminAccount && (
+              <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+                <p className="text-sm text-amber-700 dark:text-amber-200">No admin account detected. Enable the admin portal before signing in.</p>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-3 w-full"
+                  onClick={handleSetupAdmin}
+                  disabled={isSetupLoading}
+                >
+                  {isSetupLoading ? 'Enabling admin portal...' : 'Enable Admin Portal'}
+                </Button>
+              </div>
+            )}
+
             <form onSubmit={handleSubmit} className="space-y-4">
               {/* Email */}
               <div className="space-y-2">
@@ -259,7 +323,7 @@ export default function AdminLoginPage() {
                 variant="outline"
                 className="w-full"
                 onClick={handlePasskeyLogin}
-                disabled={isLoading || isPasskeyLoading}
+                disabled={isLoading || isPasskeyLoading || !hasAdminAccount}
               >
                 {isPasskeyLoading ? 'Authenticating...' : (
                   <>

--- a/src/components/effects/splash-overlay.tsx
+++ b/src/components/effects/splash-overlay.tsx
@@ -4,9 +4,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 
 const DESCRIPTORS = [
-  'Systems, composed with precision.',
-  'Applied intelligence, curated with restraint.',
-  'Operations, design, and authorship in one frame.',
+  'Operations strategy, delivered with precision.',
+  'Applied intelligence, integrated with intent.',
+  'Analysis, AI practice, and authorship in one frame.',
 ];
 
 const SIGNALS = ['Private Residence', 'Editorial Portfolio', 'Douglas Mitchell'];
@@ -124,7 +124,7 @@ export function SplashOverlay({ onComplete, minDisplayTime = 4800 }: SplashOverl
   return (
     <motion.div
       aria-label="Entrance overlay"
-      className="fixed inset-0 z-[9999] cursor-pointer overflow-hidden bg-[#050505] text-[#f4ecdd]"
+      className="fixed inset-0 z-[9999] cursor-pointer overflow-hidden bg-background text-foreground"
       initial={{ opacity: 1 }}
       animate={{ opacity: phase === 'exit' ? 0 : 1 }}
       transition={{ duration: prefersReducedMotion ? 0.2 : 0.7, ease: 'easeOut' }}
@@ -135,21 +135,21 @@ export function SplashOverlay({ onComplete, minDisplayTime = 4800 }: SplashOverl
         className="absolute inset-0"
         style={{
           background: `
-            radial-gradient(circle at 50% 34%, rgba(214, 179, 102, 0.2), transparent 0 24%),
-            radial-gradient(circle at 20% 18%, rgba(255, 240, 214, 0.1), transparent 0 18%),
-            radial-gradient(circle at 82% 20%, rgba(177, 141, 75, 0.12), transparent 0 20%),
-            linear-gradient(180deg, rgba(15, 13, 11, 0.94) 0%, rgba(7, 7, 7, 0.98) 100%)
+            radial-gradient(circle at 50% 34%, hsl(var(--primary) / 0.2), transparent 0 24%),
+            radial-gradient(circle at 20% 18%, hsl(var(--accent) / 0.18), transparent 0 18%),
+            radial-gradient(circle at 82% 20%, hsl(var(--secondary) / 0.14), transparent 0 20%),
+            linear-gradient(180deg, hsl(var(--background) / 0.96) 0%, hsl(var(--muted) / 0.98) 100%)
           `,
         }}
       />
 
       <div
         aria-hidden="true"
-        className="absolute inset-0 opacity-60"
+          className="absolute inset-0 opacity-40"
         style={{
           backgroundImage: `
-            linear-gradient(to right, rgba(255,255,255,0.035) 1px, transparent 1px),
-            linear-gradient(to bottom, rgba(255,255,255,0.025) 1px, transparent 1px)
+            linear-gradient(to right, hsl(var(--foreground) / 0.08) 1px, transparent 1px),
+            linear-gradient(to bottom, hsl(var(--foreground) / 0.06) 1px, transparent 1px)
           `,
           backgroundSize: '72px 72px',
           maskImage: 'radial-gradient(circle at center, black 40%, transparent 88%)',
@@ -158,9 +158,9 @@ export function SplashOverlay({ onComplete, minDisplayTime = 4800 }: SplashOverl
 
       <div
         aria-hidden="true"
-        className="absolute inset-[24px] rounded-[32px] border border-white/8"
+        className="absolute inset-[24px] rounded-[32px] border border-border/70"
         style={{
-          boxShadow: 'inset 0 0 0 1px rgba(205, 179, 128, 0.14), inset 0 0 140px rgba(255, 255, 255, 0.03)',
+          boxShadow: 'inset 0 0 0 1px hsl(var(--primary) / 0.14), inset 0 0 140px hsl(var(--foreground) / 0.04)',
         }}
       />
 
@@ -276,7 +276,7 @@ export function SplashOverlay({ onComplete, minDisplayTime = 4800 }: SplashOverl
                     className="text-[clamp(2.9rem,7.6vw,5.8rem)] font-light leading-none tracking-[0.08em] text-[#fff7eb]"
                     style={{ fontFamily: titleFont }}
                   >
-                    The Architect
+                    Operations Analyst
                   </h1>
                   <p className="mx-auto max-w-[34rem] text-sm leading-7 text-[#efe2c6]/72 sm:text-base">
                     A refined portfolio of operations, intelligent systems, and authored perspective.
@@ -320,7 +320,7 @@ export function SplashOverlay({ onComplete, minDisplayTime = 4800 }: SplashOverl
 
             <div className="flex flex-col items-center justify-between gap-3 border-t border-white/8 pt-5 text-[0.62rem] uppercase tracking-[0.32em] text-[#c8ad7e]/58 sm:flex-row sm:text-[0.68rem]">
               <span>Enter or click to continue</span>
-              <span>Luxury motion system</span>
+              <span>Editorial motion system</span>
             </div>
           </div>
         </motion.div>

--- a/src/components/site/enhanced-hero-section.tsx
+++ b/src/components/site/enhanced-hero-section.tsx
@@ -8,7 +8,7 @@ import { heroMetrics, siteProfile, socialLinks } from '@/lib/site-content';
 const roles = [
   'Operations Analyst',
   'AI Practitioner', 
-  'Systems Architect',
+  'Systems Strategist',
   'Author',
 ];
 
@@ -16,7 +16,7 @@ const asciiArt = `
     ╭────────────────────────────────────╮
     │                                    │
     │    ┏━━━━━━━━━━━━━━━━━━━━━━┓       │
-    │    ┃   THE  ARCHITECT    ┃       │
+    │    ┃ OPERATIONS ANALYST  ┃       │
     │    ┗━━━━━━━━━━━━━━━━━━━━━━┛       │
     │                                    │
     │    • Operations Analysis          │
@@ -132,7 +132,7 @@ export function EnhancedHeroSection() {
           >
             <span className="font-mono text-xs text-muted-foreground">{'[ '}</span>
             <Sparkles className="h-4 w-4 text-primary" />
-            <span className="font-mono text-sm">The Architect</span>
+            <span className="font-mono text-sm">Operations Analyst</span>
             <span className="font-mono text-xs text-muted-foreground">{' ]'}</span>
           </motion.div>
 

--- a/src/lib/site-content.ts
+++ b/src/lib/site-content.ts
@@ -90,7 +90,7 @@ export interface ContactMethod {
 
 export const siteProfile = {
   name: 'Douglas Mitchell',
-  headline: 'Operations Analyst, AI Practitioner, Systems Architect, and Author.',
+  headline: 'Operations Analyst, AI Practitioner, Systems Strategist, and Author.',
   summary:
     'I design resilient systems that blend operational rigor, AI fluency, and human-centered execution. The result is proof-driven work that looks premium and performs in the real world.',
   location: 'Houston, TX',
@@ -700,9 +700,9 @@ export const aboutRoles = [
     stats: 'Published book + companion ecosystem',
   },
   {
-    title: 'Systems Architect',
+    title: 'Operations Analyst',
     description:
-      'Connects product thinking, technical execution, and operational discipline into coherent systems.',
-    stats: '85+ repositories of public proof',
+      'Connects product thinking, technical execution, and operational discipline into measurable operating outcomes.',
+    stats: 'Systems-level execution',
   },
 ];


### PR DESCRIPTION
### Motivation
- Provide a reusable Gravatar integration reference for AI/developer workflows and link it from the project README. 
- Surface and enable an initial admin account if none exists so the admin portal can be initialized from the UI. 
- Tighten passkey authentication client calls and error handling to match renamed server endpoints. 
- Refresh UI copy and visual theming to use design system tokens and updated role/headline language.

### Description
- Added `LLMS.TXT` containing Gravatar API guidance, a TypeScript hashing/fetch reference, and quick test commands, and linked it from `README.md`. 
- Enhanced `src/app/admin/login/page.tsx` to check admin account presence on mount, provide an admin setup flow (`POST /api/admin/setup`), disable passkey sign-in when no admin exists, and updated passkey client calls to `POST /api/admin/auth/passkey/generate-options` and `POST /api/admin/auth/passkey/verify` (and improved error typing/messages). 
- Updated `src/components/effects/splash-overlay.tsx` to replace hardcoded colors/gradients with CSS variables, adjust background/overlay opacity and copy, and refine descriptor/signals and microcopy. 
- Updated hero and site content strings in `src/components/site/enhanced-hero-section.tsx` and `src/lib/site-content.ts` to reflect new role/headline language and ASCII art/metrics text changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b103f8e2108328ae7fe95f68bfb85c)